### PR TITLE
Remove pricing from services section

### DIFF
--- a/index.html
+++ b/index.html
@@ -180,9 +180,9 @@
 <section id="services">
   <h2>Our Services</h2>
   <div class="services-grid">
-    <div class="card"><h3>Site Sprint</h3><p>1–3 page responsive website, performance‑optimized, basic SEO-delivered within two weeks.</p><p class="price">$1,250</p></div>
-    <div class="card"><h3>Growth Bundle</h3><p>Everything in Site Sprint plus a brand‑matched social launch pack-12 posts, captions and a 30‑day calendar.</p><p class="price">$2,600</p></div>
-    <div class="card"><h3>Season‑Long Care</h3><p>Ongoing updates, hosting, analytics and eight social posts every month to keep your audience engaged.</p><p class="price">$175 / mo (or $1,800 yr paid in full)</p></div>
+    <div class="card"><h3>Site Sprint</h3><p>1–3 page responsive website, performance‑optimized, basic SEO-delivered within two weeks.</p></div>
+    <div class="card"><h3>Growth Bundle</h3><p>Everything in Site Sprint plus a brand‑matched social launch pack-12 posts, captions and a 30‑day calendar.</p></div>
+    <div class="card"><h3>Season‑Long Care</h3><p>Ongoing updates, hosting, analytics and eight social posts every month to keep your audience engaged.</p></div>
   </div>
 </section>
 


### PR DESCRIPTION
Removed all pricing information from the three service cards (Site Sprint, Growth Bundle, and Season-Long Care) in the services section of the homepage.