### PR TITLE
Remove discovery call button and adjust hero layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -65,7 +65,7 @@
       margin:0 0 12px;            /* remove gap between logo and headline */
       line-height:1.05;
     }
-    .hero p{font-size:clamp(1rem,2.2vw,1.35rem);max-width:680px;margin-bottom:38px;}
+    .hero p{font-size:clamp(1rem,2.2vw,1.35rem);max-width:680px;margin-bottom:0;}
     .btn{background:var(--cyan);color:var(--black);padding:16px 40px;font-weight:700;border:none;border-radius:6px;
       cursor:pointer;box-shadow:0 0 14px var(--cyan);transition:transform .25s,box-shadow .25s;}
     .btn:hover{transform:translateY(-3px) scale(1.03);box-shadow:0 0 20px var(--cyan);}
@@ -120,7 +120,7 @@
       }
       .hero p{
         font-size:1rem;
-        margin-bottom:30px;
+        margin-bottom:0;
       }
       .services-grid{
         grid-template-columns:1fr;     /* single column cards */
@@ -174,7 +174,6 @@
   <br>
   <h1>Websites that win and socials that sell.</h1><br>
   <p>We build websites that do more than just look good, they work. Our focus is on delivering clean, functional websites fast for businesses in Gettysburg and throughout Central Pennsylvania, plus the social campaigns that drive traffic to them.</p>
-  <a href="https://calendly.com/kevin-fortneydesignco/30min" target="_blank" rel="noopener noreferrer" class="btn">Book a Free Discovery Call</a>
 </section>
 
 <section id="services">


### PR DESCRIPTION
Removed the "Book a Free Discovery Call" button from the hero section
and set hero paragraph margin-bottom to 0 (both desktop and mobile)
to accommodate the new blank space.

https://claude.ai/code/session_01AfHeLcdt584yVkZ6kqrRPn